### PR TITLE
Change search ID from int to canonical UUID String

### DIFF
--- a/opendiamond/protocol.py
+++ b/opendiamond/protocol.py
@@ -54,7 +54,6 @@ class XDR_attribute(XDRStruct):
 class XDR_object(XDRStruct):
     '''Blast channel object data'''
     members = (
-        'search_id', XDR.uint(),
         # was object data, now stored in attrs['']
         None, XDR.constant(XDR.opaque(), ''),
         'attrs', XDR.array(XDR.struct(XDR_attribute)),
@@ -99,7 +98,7 @@ class XDR_blob_data(XDRStruct):
 class XDR_start(XDRStruct):
     '''Start-search parameters'''
     members = (
-        'search_id', XDR.uint(),
+        'search_id', XDR.fstring(36),
         'attrs', XDR.optional(XDR.array(XDR.string(MAX_ATTRIBUTE_NAME))),
     )
 

--- a/opendiamond/server/object_.py
+++ b/opendiamond/server/object_.py
@@ -101,9 +101,9 @@ class EmptyObject(object):
             attrs.append(XDR_attribute(name, value))
         return attrs
 
-    def xdr(self, search_id, output_set=None):
+    def xdr(self, output_set=None):
         '''Return an XDR_object.'''
-        return XDR_object(search_id, self.xdr_attributes(output_set))
+        return XDR_object(self.xdr_attributes(output_set))
 
 
 class Object(EmptyObject):

--- a/opendiamond/server/search.py
+++ b/opendiamond/server/search.py
@@ -174,7 +174,7 @@ class Search(RPCHandlers):
         for blob in params.blobs:
             self._state.blob_cache.add(blob)
 
-    @RPCHandlers.handler(27, protocol.XDR_start)
+    @RPCHandlers.handler(28, protocol.XDR_start)
     @running(False)
     def start(self, params):
         '''Start the search.'''
@@ -277,10 +277,10 @@ class BlastChannel(object):
 
     def send(self, obj):
         '''Send the specified Object on the blast channel.'''
-        xdr = obj.xdr(self._search_id, self._push_attrs)
+        xdr = obj.xdr(self._push_attrs)
         _BlastChannelSender(xdr).send(self._conn)
 
     def close(self):
         '''Tell the client that no more objects will be returned.'''
-        xdr = EmptyObject().xdr(self._search_id)
+        xdr = EmptyObject().xdr()
         _BlastChannelSender(xdr).send(self._conn)


### PR DESCRIPTION
The current search ID uses int, and for randomness and because of XDR
alignment requirements, a lot of transformation needs to be done. This
could be done in a cleaner way using UUID.

Remove search Id field in object for two reasons:
- Object uses long search Id, and does not encode string UUID
- Search ID field will be removed from objects in the future

Change start RPC number (from 27 to 28).
