### PR TITLE
Remove search ID andat data from object

### DIFF
--- a/opendiamond/protocol.py
+++ b/opendiamond/protocol.py
@@ -54,9 +54,6 @@ class XDR_attribute(XDRStruct):
 class XDR_object(XDRStruct):
     '''Blast channel object data'''
     members = (
-        'search_id', XDR.uint(),
-        # was object data, now stored in attrs['']
-        None, XDR.constant(XDR.opaque(), ''),
         'attrs', XDR.array(XDR.struct(XDR_attribute)),
     )
 

--- a/opendiamond/server/object_.py
+++ b/opendiamond/server/object_.py
@@ -101,9 +101,9 @@ class EmptyObject(object):
             attrs.append(XDR_attribute(name, value))
         return attrs
 
-    def xdr(self, search_id, output_set=None):
+    def xdr(self, output_set=None):
         '''Return an XDR_object.'''
-        return XDR_object(search_id, self.xdr_attributes(output_set))
+        return XDR_object(self.xdr_attributes(output_set))
 
 
 class Object(EmptyObject):

--- a/opendiamond/server/search.py
+++ b/opendiamond/server/search.py
@@ -254,7 +254,7 @@ class _BlastChannelSender(RPCHandlers):
         self._obj = obj
         self._sent = False
 
-    @RPCHandlers.handler(1, reply_class=protocol.XDR_object)
+    @RPCHandlers.handler(2, reply_class=protocol.XDR_object)
     def get_object(self):
         '''Return an accepted object.'''
         assert not self._sent
@@ -277,10 +277,10 @@ class BlastChannel(object):
 
     def send(self, obj):
         '''Send the specified Object on the blast channel.'''
-        xdr = obj.xdr(self._search_id, self._push_attrs)
+        xdr = obj.xdr(self._push_attrs)
         _BlastChannelSender(xdr).send(self._conn)
 
     def close(self):
         '''Tell the client that no more objects will be returned.'''
-        xdr = EmptyObject().xdr(self._search_id)
+        xdr = EmptyObject().xdr()
         _BlastChannelSender(xdr).send(self._conn)


### PR DESCRIPTION
In the past, search ID was used for relating objects to searches because
searches for different channels were done on different channels. Now all
searches are done on the same channel, and it is unnecessary to relate
objects to searches. Therefore, remove search ID from objects.

Also, remove data field from object since it is not used anymore.
Object data is now stored in the attributes list with the zero-length
string key.

Change get_object RPC to 2 (from 1).
