### PR TITLE
diamondd: Replace XDRFStringHandler with XDRFOpaqueHandler

### DIFF
--- a/opendiamond/protocol.py
+++ b/opendiamond/protocol.py
@@ -96,7 +96,7 @@ class XDR_blob_data(XDRStruct):
 class XDR_start(XDRStruct):
     '''Start-search parameters'''
     members = (
-        'search_id', XDR.fstring(36),
+        'search_id', XDR.fopaque(36),
         'attrs', XDR.optional(XDR.array(XDR.string(MAX_ATTRIBUTE_NAME))),
     )
 

--- a/opendiamond/xdr.py
+++ b/opendiamond/xdr.py
@@ -47,7 +47,7 @@ class _XDRPrimitiveHandler(_XDRTypeHandler):
         return self._check(getattr(xdr, 'unpack_' + self._name)())
 
 
-class _XDRFStringHandler(_XDRTypeHandler):
+class _XDRFOpaqueHandler(_XDRTypeHandler):
     def __init__(self, length):
         _XDRTypeHandler.__init__(self)
         self._length = length
@@ -58,10 +58,10 @@ class _XDRFStringHandler(_XDRTypeHandler):
         return val
 
     def pack(self, xdr, val):
-        xdr.pack_fstring(self._length, self._check(val))
+        xdr.pack_fopaque(self._length, self._check(val))
 
     def unpack(self, xdr):
-        return self._check(xdr.unpack_fstring(self._length))
+        return self._check(xdr.unpack_fopaque(self._length))
 
 
 class _XDRIntHandler(_XDRTypeHandler):
@@ -174,8 +174,8 @@ class XDR(object):
         return _XDRPrimitiveHandler('opaque')
 
     @staticmethod
-    def fstring(length):
-        return _XDRFStringHandler(length)
+    def fopaque(length):
+        return _XDRFOpaqueHandler(length)
 
     @staticmethod
     def array(item_handler, max_length=None):


### PR DESCRIPTION
RFC 4506 does not define serialization for fixed length strings. Replace
the fixed length string handler with a fixed length opaque handler.
