### PR TITLE
Adding fix for xml2rfc out-of-date errors.

### DIFF
--- a/doc/diamond-protocol.xml
+++ b/doc/diamond-protocol.xml
@@ -44,7 +44,7 @@
                 <email>rahul AT cs DOT cmu DOT edu</email>
             </address>
         </author>
-        <date year="2012" />
+        <date year="2012" month="1"/>
         <keyword>diamond</keyword>
         <keyword>Diamond</keyword>
         <keyword>Carnegie Mellon</keyword>


### PR DESCRIPTION
Fix for bug #43. Adding an explicit month to the date seems to fix the xml2rfc error.