### PR TITLE
Fixing potential memory leak

### DIFF
--- a/opendiamond/server/filter.py
+++ b/opendiamond/server/filter.py
@@ -299,10 +299,14 @@ class _FilterTCP(_FilterConnection):
         if self._close:
             try:
                 self._sock.shutdown(socket.SHUT_RDWR)
-                self._sock.close()
                 # _log.debug('Filter %s closed connection.' % self)
-            except IOError:
+            except (IOError, OSError):
                 # _log.info('Filter %s did not close connection properly' % self)
+                pass
+
+            try:
+                self._sock.close()
+            except (IOError, OSError):
                 pass
 
     def hint_large_attribute(self, size):


### PR DESCRIPTION
The potential problem I am fixing here occurs when `socket.shutdown` fails and doesn’t proceed to `socket.close` to clean up the socket and allow garbage collection to release the memory used for it.

The `OSError` on shutdown can occur when the remote side of the connection closes the connection first.